### PR TITLE
Add FileUpload::fromFile() for easier testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /phpunit.xml
 /.phpunit.result.cache
 /.phpcs-cache
+/coverage.xml

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![Psalm Level](https://shepherd.dev/github/koriym/Koriym.FileUpload/level.svg)](https://shepherd.dev/github/koriym/Koriym.FileUpload)
 [![Continuous Integration](https://github.com/koriym/Koriym.FileUpload/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/koriym/Koriym.FileUpload/actions/workflows/continuous-integration.yml)
 
-
 Type-safe file upload handling with immutable value objects.
 
 ## Installation
@@ -16,6 +15,7 @@ composer require koriym/file-upload
 
 ## Usage
 
+### From $_FILES
 ```php
 $upload = FileUpload::create($_FILES['upload'], [
     'maxSize' => 5 * 1024 * 1024,          // 5MB
@@ -28,6 +28,19 @@ match (true) {
         ? 'Upload successful'
         : 'Failed to move file',
     $upload instanceof ErrorFileUpload => 'Error: ' . $upload->message,
+};
+```
+
+### From File Path (for Testing)
+```php
+$upload = FileUpload::fromFile('/path/to/image.jpg', [
+    'maxSize' => 5 * 1024 * 1024,
+    'allowedTypes' => ['image/jpeg', 'image/png']
+]);
+
+match (true) {
+    $upload instanceof FileUpload => 'File validated successfully',
+    $upload instanceof ErrorFileUpload => 'Validation error: ' . $upload->message,
 };
 ```
 
@@ -51,13 +64,14 @@ public ?string $message;   // Error message
 
 ## Validation Options
 
-You can pass the following validation options to `create()`:
+You can pass the following validation options to both `create()` and `fromFile()`:
 - `maxSize`: Maximum file size in bytes
 - `allowedTypes`: Array of allowed MIME types
 - `allowedExtensions`: Array of allowed file extensions
 
 ## Testing
 
+### Using toArray()
 The library provides a `toArray()` method to convert a FileUpload object back to `$_FILES` format array, which is useful for creating test stubs:
 
 ```php
@@ -72,7 +86,23 @@ $upload = FileUpload::create([
 $fileData = $upload->toArray();  // Returns $_FILES format array
 ```
 
-The `move()` method behaves differently in CLI and web environments:
+### Using fromFile()
+For more realistic testing scenarios, you can create a FileUpload instance directly from a file:
+
+```php
+// Create from actual image file
+$upload = FileUpload::fromFile('/path/to/test/image.jpg');
+
+// Create with validation
+$upload = FileUpload::fromFile('/path/to/test/doc.pdf', [
+    'maxSize' => 1024 * 1024,
+    'allowedTypes' => ['application/pdf']
+]);
+```
+
+This is particularly useful when you want to test with real files and MIME types.
+
+Note: The `move()` method behaves differently in CLI and web environments:
 - In web environment: Uses `move_uploaded_file()` for security
 - In CLI environment (testing): Uses `rename()` for testability
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@
 
 Type-safe file upload handling with immutable value objects.
 
+## Motivation
+
+Testing file uploads in PHP applications is traditionally complex and time-consuming. It often requires setting up a built-in web server, making HTTP requests, and managing multipart form data. This approach leads to slow, unreliable tests that are difficult to debug and maintain, especially in CI environments.
+
+This library simplifies both the handling of file uploads and their testing. Instead of dealing with PHP's native `$_FILES` array directly, you work with immutable value objects that provide type safety and early validation. For testing, rather than simulating HTTP file uploads, you can create test instances directly from files on your filesystem. This approach makes tests faster, more reliable, and easier to debug while still testing real-world scenarios with actual file types and contents.
+
 ## Installation
 
 ```bash

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         }
     ],
     "require": {
-        "php": "^8.1"
+        "php": "^8.1",
+        "ext-fileinfo": "*"
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.8",

--- a/src/Exception/FileNotFoundException.php
+++ b/src/Exception/FileNotFoundException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\FileUpload\Exception;
+
+class FileNotFoundException extends FileUploadException
+{
+}

--- a/src/Exception/MimeTypeException.php
+++ b/src/Exception/MimeTypeException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\FileUpload\Exception;
+
+class MimeTypeException extends FileUploadException
+{
+}

--- a/src/Exception/TempFileException.php
+++ b/src/Exception/TempFileException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\FileUpload\Exception;
+
+class TempFileException extends FileUploadException
+{
+}

--- a/src/FileUpload.php
+++ b/src/FileUpload.php
@@ -149,26 +149,25 @@ class FileUpload extends AbstractFileUpload
 
         $mimeType = mime_content_type($filepath);
         if ($mimeType === false) {
-            throw new MimeTypeException($filepath);
+            throw new MimeTypeException($filepath); // @codeCoverageIgnore
         }
 
         $size = filesize($filepath);
-        if ($size === false) {
-            throw new MimeTypeException($filepath);
-        }
 
         $tmpName = tempnam(sys_get_temp_dir(), 'upload_test');
         if ($tmpName === false) {
-            throw new TempFileException($filepath);
+            throw new TempFileException($filepath); // @codeCoverageIgnore
         }
 
         if (! copy($filepath, $tmpName)) {
+            // @codeCoverageIgnoreStart
             unlink($tmpName);
 
             throw new TempFileException($filepath);
+            // @codeCoverageIgnoreEnd
         }
 
-        /** @var array{name: string, type: string, size: int, tmp_name: string, error: int} */
+        /** @var UploadedFile $fileData */
         $fileData = [
             'name' => pathinfo($filepath, PATHINFO_BASENAME),
             'type' => $mimeType,

--- a/tests/FileUploadFromFileTest.php
+++ b/tests/FileUploadFromFileTest.php
@@ -6,6 +6,8 @@ namespace Koriym\FileUpload;
 
 use Koriym\FileUpload\Exception\FileNotFoundException;
 use PHPUnit\Framework\TestCase;
+
+use function base64_decode;
 use function file_put_contents;
 use function sys_get_temp_dir;
 use function tempnam;
@@ -61,7 +63,7 @@ class FileUploadFromFileTest extends TestCase
         $validationOptions = [
             'maxSize' => 1024 * 1024,
             'allowedTypes' => ['image/jpeg'],
-            'allowedExtensions' => ['jpg']
+            'allowedExtensions' => ['jpg'],
         ];
 
         $upload = FileUpload::fromFile($this->testImagePath, $validationOptions);
@@ -72,7 +74,7 @@ class FileUploadFromFileTest extends TestCase
     public function testFromFileWithValidationFailure(): void
     {
         $validationOptions = [
-            'allowedTypes' => ['application/pdf']
+            'allowedTypes' => ['application/pdf'],
         ];
 
         $upload = FileUpload::fromFile($this->testTextPath, $validationOptions);

--- a/tests/FileUploadFromFileTest.php
+++ b/tests/FileUploadFromFileTest.php
@@ -6,8 +6,6 @@ namespace Koriym\FileUpload;
 
 use Koriym\FileUpload\Exception\FileNotFoundException;
 use PHPUnit\Framework\TestCase;
-
-use function base64_decode;
 use function file_put_contents;
 use function sys_get_temp_dir;
 use function tempnam;
@@ -51,8 +49,10 @@ class FileUploadFromFileTest extends TestCase
     public function testFromFileEmpty(): void
     {
         $upload = FileUpload::fromFile($this->emptyFilePath);
+
         $this->assertInstanceOf(FileUpload::class, $upload);
         $this->assertSame(0, $upload->size);
+        $this->assertSame('application/x-empty', $upload->type);
         @unlink($upload->tmpName);
     }
 
@@ -61,7 +61,7 @@ class FileUploadFromFileTest extends TestCase
         $validationOptions = [
             'maxSize' => 1024 * 1024,
             'allowedTypes' => ['image/jpeg'],
-            'allowedExtensions' => ['jpg'],
+            'allowedExtensions' => ['jpg']
         ];
 
         $upload = FileUpload::fromFile($this->testImagePath, $validationOptions);
@@ -72,7 +72,7 @@ class FileUploadFromFileTest extends TestCase
     public function testFromFileWithValidationFailure(): void
     {
         $validationOptions = [
-            'allowedTypes' => ['application/pdf'],
+            'allowedTypes' => ['application/pdf']
         ];
 
         $upload = FileUpload::fromFile($this->testTextPath, $validationOptions);

--- a/tests/FileUploadFromFileTest.php
+++ b/tests/FileUploadFromFileTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Koriym\FileUpload;
+
+use Koriym\FileUpload\Exception\FileUploadException;
+use PHPUnit\Framework\TestCase;
+
+use function base64_decode;
+use function file_put_contents;
+use function sys_get_temp_dir;
+use function tempnam;
+use function unlink;
+
+class FileUploadFromFileTest extends TestCase
+{
+    private string $testImagePath;
+    private string $testTextPath;
+
+    protected function setUp(): void
+    {
+        // Create JPEG images for testing
+        $this->testImagePath = tempnam(sys_get_temp_dir(), 'test_image_') . '.jpg';
+        file_put_contents($this->testImagePath, base64_decode('/9j/4AAQSkZJRgABAQEAYABgAAD/4QBmRXhpZgAATU0AKgAAAAgABAEaAAUAAAABAAAAPgEbAAUAAAABAAAARgEoAAMAAAABAAIAAAExAAIAAAAQAAAATgAAAAAAAABgAAAAAQAAAGAAAAABcGFpbnQubmV0IDUuMC41AP/bAEMABQMEBAQDBQQEBAUFBQYHDAgHBwcHDwsLCQwRDxISEQ8RERMWHBcTFBoVEREYIRgaHR0fHx8TFyIkIh4kHB4fHv/bAEMBBQUFBwYHDggIDh4UERQeHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHv/AABEIAAEAAQMBIgACEQEDEQH/xAAVAAEBAAAAAAAAAAAAAAAAAAAABv/EAB0QAAICAgMBAAAAAAAAAAAAAAABAgMEBREhQRP/xAAUAQEAAAAAAAAAAAAAAAAAAAAA/8QAFBEBAAAAAAAAAAAAAAAAAAAAAP/aAAwDAQACEQMRAD8AoNxbhMLl7knbXOUJvmDhLx/YAg//2Q=='));
+
+        // Create text for testing
+        $this->testTextPath = tempnam(sys_get_temp_dir(), 'test_text_') . '.txt';
+        file_put_contents($this->testTextPath, 'Hello, World!');
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->testImagePath);
+        @unlink($this->testTextPath);
+    }
+
+    public function testFromFileSuccess(): void
+    {
+        $upload = FileUpload::fromFile($this->testImagePath);
+
+        $this->assertInstanceOf(FileUpload::class, $upload);
+        $this->assertStringEndsWith('.jpg', $upload->name);
+        $this->assertGreaterThan(0, $upload->size);
+        $this->assertFileExists($upload->tmpName);
+        $this->assertEquals('image/jpeg', $upload->type);
+
+        // Clean up temporary file
+        @unlink($upload->tmpName);
+    }
+
+    public function testFromFileWithValidation(): void
+    {
+        $validationOptions = [
+            'maxSize' => 1024 * 1024,  // 1MB
+            'allowedTypes' => ['image/jpeg'],
+            'allowedExtensions' => ['jpg'],
+        ];
+
+        $upload = FileUpload::fromFile($this->testImagePath, $validationOptions);
+        $this->assertInstanceOf(FileUpload::class, $upload);
+
+        // Clean up temporary file
+        @unlink($upload->tmpName);
+    }
+
+    public function testFromFileWithValidationFailure(): void
+    {
+        $validationOptions = [
+            'allowedTypes' => ['application/pdf'],
+        ];
+
+        $upload = FileUpload::fromFile($this->testTextPath, $validationOptions);
+        $this->assertInstanceOf(ErrorFileUpload::class, $upload);
+        $this->assertIsString($upload->message);
+        $this->assertStringContainsString('type text/plain is not allowed', $upload->message);
+    }
+
+    public function testFromFileNonExistentFile(): void
+    {
+        $this->expectException(FileUploadException::class);
+        $this->expectExceptionMessage('File not found');
+
+        FileUpload::fromFile('/path/to/nonexistent/file.jpg');
+    }
+}


### PR DESCRIPTION
File upload testing traditionally requires setting up a built-in web server and making HTTP requests, which makes tests slow and unreliable. This PR introduces `FileUpload::fromFile()` to create test instances directly from files on the filesystem.

## Features

* New `FileUpload::fromFile()` method for creating instances from actual files
* Real MIME type detection and validation with actual files
* No HTTP server or requests needed for testing
* Simpler and more reliable tests in CI environments

## Example

```php
// Create from actual file with validation
$upload = FileUpload::fromFile('/path/to/test.jpg', [
    'maxSize' => 1024 * 1024,
    'allowedTypes' => ['image/jpeg']
]);

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a new method for creating `FileUpload` instances directly from file paths, enhancing testing capabilities.
  - Added new exception classes for better error handling during file uploads.

- **Documentation**
  - Updated `README.md` to clarify library functionality and added a "Motivation" section.
  - Expanded usage examples and added a new section on converting `FileUpload` objects back to the `$_FILES` format.

- **Chores**
  - Updated `.gitignore` to exclude `coverage.xml`.
  - Modified `composer.json` to include the `ext-fileinfo` requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->