### PR TITLE
Add testing tips for handling file uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ $fileData = $upload->toArray();  // Returns $_FILES format array
 For more realistic testing scenarios, you can create a FileUpload instance directly from a file:
 
 ```php
-// Create from actual image file
-$upload = FileUpload::fromFile('/path/to/test/image.jpg');
+// Place test files in your project's tests/fixtures directory
+$upload = FileUpload::fromFile(__DIR__ . '/fixtures/test-image.jpg');
 
 // Create with validation
 $upload = FileUpload::fromFile('/path/to/test/doc.pdf', [

--- a/README.md
+++ b/README.md
@@ -112,6 +112,34 @@ Note: The `move()` method behaves differently in CLI and web environments:
 - In web environment: Uses `move_uploaded_file()` for security
 - In CLI environment (testing): Uses `rename()` for testability
 
+## Testing Tips
+
+### Testing Code That Depends on $_FILES
+
+When testing code that depends on $_FILES, you can use the combination of `fromFile()` and `toArray()`:
+
+```php
+// Setup test file upload
+$upload = FileUpload::fromFile('/path/to/test/image.jpg');
+$fileData = $upload->toArray();
+
+// Backup current $_FILES state if needed
+$backupFiles = $_FILES;
+
+try {
+    // Simulate uploaded file in $_FILES
+    $_FILES['upload'] = $fileData;
+    
+    // Test your code that depends on $_FILES
+    $result = $yourCode->handleUpload();
+    
+    // Assert results
+    $this->assertTrue($result);
+} finally {
+    // Restore original $_FILES state
+    $_FILES = $backupFiles;
+}
+
 ## Similar Libraries
 
 Both Symfony HttpFoundation and Laravel provide file upload handling as part of their frameworks. While these frameworks offer more comprehensive features including storage abstraction and integration with their ecosystems, Koriym.FileUpload takes a more focused approach by providing a lightweight, framework-independent solution that transforms PHP's native $_FILES array into type-safe immutable objects.

--- a/README.md
+++ b/README.md
@@ -116,29 +116,9 @@ Note: The `move()` method behaves differently in CLI and web environments:
 
 ### Testing Code That Depends on $_FILES
 
-When testing code that depends on $_FILES, you can use the combination of `fromFile()` and `toArray()`:
+When testing code that depends on $_FILES, you can use the combination of `fromFile()` and `toArray()` to create controlled, reproducible tests without the complexity of setting up actual HTTP file uploads:
 
-```php
-// Setup test file upload
-$upload = FileUpload::fromFile('/path/to/test/image.jpg');
-$fileData = $upload->toArray();
-
-// Backup current $_FILES state if needed
-$backupFiles = $_FILES;
-
-try {
-    // Simulate uploaded file in $_FILES
-    $_FILES['upload'] = $fileData;
-    
-    // Test your code that depends on $_FILES
-    $result = $yourCode->handleUpload();
-    
-    // Assert results
-    $this->assertTrue($result);
-} finally {
-    // Restore original $_FILES state
-    $_FILES = $backupFiles;
-}
+See the example in [docs/UploadHandlerTest.php](docs/UploadHandlerTest.php).
 
 ## Similar Libraries
 

--- a/docs/UploadHandlerTest.php
+++ b/docs/UploadHandlerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use Koriym\FileUpload\FileUpload;
+use PHPUnit\Framework\TestCase;
+
+class UploadHandlerTest extends TestCase
+{
+    private array $originalFiles;
+
+    protected function setUp(): void
+    {
+        $this->originalFiles = $_FILES;
+    }
+
+    protected function tearDown(): void
+    {
+        $_FILES = $this->originalFiles;
+    }
+
+    public function testSuccessfulUpload(): void
+    {
+        // Setup test file upload
+        $upload = FileUpload::fromFile(__DIR__ . '/fixtures/valid-image.jpg');
+        $_FILES['upload'] = $upload->toArray();
+
+        $handler = new UploadHandler();
+        $result = $handler->handleUpload();
+
+        $this->assertFileExists('/path/to/uploads/valid-image.jpg');
+        $this->assertEquals('image/jpeg', $result->getContentType());
+        $this->assertGreaterThan(0, $result->getSize());
+    }
+
+    public function testInvalidFileType(): void
+    {
+        $upload = FileUpload::fromFile(__DIR__ . '/fixtures/invalid.exe');
+        $_FILES['upload'] = $upload->toArray();
+
+        $handler = new UploadHandler();
+
+        $this->expectException(InvalidFileTypeException::class);
+        $handler->handleUpload();
+    }
+}

--- a/docs/UploadHandlerTest.php
+++ b/docs/UploadHandlerTest.php
@@ -23,9 +23,10 @@ class UploadHandlerTest extends TestCase
         $upload = FileUpload::fromFile(__DIR__ . '/fixtures/valid-image.jpg');
         $_FILES['upload'] = $upload->toArray();
 
-        $handler = new UploadHandler();
-        $result = $handler->handleUpload();
+        $handler = new YourUploadHandler();
 
+        // Test your code that depends on $_FILES
+        $result = $handler->handleUpload();
         $this->assertFileExists('/path/to/uploads/valid-image.jpg');
         $this->assertEquals('image/jpeg', $result->getContentType());
         $this->assertGreaterThan(0, $result->getSize());
@@ -36,7 +37,7 @@ class UploadHandlerTest extends TestCase
         $upload = FileUpload::fromFile(__DIR__ . '/fixtures/invalid.exe');
         $_FILES['upload'] = $upload->toArray();
 
-        $handler = new UploadHandler();
+        $handler = new YourUploadHandler();
 
         $this->expectException(InvalidFileTypeException::class);
         $handler->handleUpload();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Introduced a new section "Testing Tips" in the README.md to guide users on testing code with the `$_FILES` superglobal, including a code snippet for file uploads.
- **New Features**
	- Added a new test suite for the `UploadHandler` class in UploadHandlerTest.php, covering both successful and erroneous file upload scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->